### PR TITLE
fix: wrong links in gem guided_tour.gemspec

### DIFF
--- a/guided_tour.gemspec
+++ b/guided_tour.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/its-bede/guided-tour"
-  spec.metadata["changelog_uri"] = "https://github.com/its-bede/guided-tourblob/main/CHANGELOG.md"
+  spec.metadata["source_code_uri"] = "https://github.com/its-bede/guided_tour"
+  spec.metadata["changelog_uri"] = "https://github.com/its-bede/guided_tour/blob/main/CHANGELOG.md"
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]


### PR DESCRIPTION
- fixes #12
- use underscore instead of dash in uri
- add missing slash

Refs: https://github.com/its-bede/guided_tour/issues/12